### PR TITLE
Update Laravel Vite plugin

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
                 "autoprefixer": "^10.4.0",
                 "cross-env": "^7.0",
                 "css-loader": "^5.2.7",
-                "laravel-vite-plugin": "^0.5.3",
+                "laravel-vite-plugin": "^0.6.1",
                 "postcss": "^8.4.5",
                 "postcss-import": "^14.0.1",
                 "tailwindcss": "^3.0.19",
@@ -1444,9 +1444,9 @@
             }
         },
         "node_modules/laravel-vite-plugin": {
-            "version": "0.5.3",
-            "resolved": "https://registry.npmjs.org/laravel-vite-plugin/-/laravel-vite-plugin-0.5.3.tgz",
-            "integrity": "sha512-7Sujs+ywIYQai7lfpn+KxkRCAz/RWVMO8VryheEyUCKBsEITRyLoml5kudMW/rWJCKhSVVSIF3KkYZ3pDmDZzg==",
+            "version": "0.6.1",
+            "resolved": "https://registry.npmjs.org/laravel-vite-plugin/-/laravel-vite-plugin-0.6.1.tgz",
+            "integrity": "sha512-L8zt+bttm6+C0mo3an5J8wRW03SsjbTEouGb3bH2jj/XclFVAX/xEUkG9efhdRHjbEH5RY6cmdJ7bmf7zqjwIQ==",
             "dev": true,
             "dependencies": {
                 "vite-plugin-full-reload": "^1.0.1"
@@ -3500,9 +3500,9 @@
             "dev": true
         },
         "laravel-vite-plugin": {
-            "version": "0.5.3",
-            "resolved": "https://registry.npmjs.org/laravel-vite-plugin/-/laravel-vite-plugin-0.5.3.tgz",
-            "integrity": "sha512-7Sujs+ywIYQai7lfpn+KxkRCAz/RWVMO8VryheEyUCKBsEITRyLoml5kudMW/rWJCKhSVVSIF3KkYZ3pDmDZzg==",
+            "version": "0.6.1",
+            "resolved": "https://registry.npmjs.org/laravel-vite-plugin/-/laravel-vite-plugin-0.6.1.tgz",
+            "integrity": "sha512-L8zt+bttm6+C0mo3an5J8wRW03SsjbTEouGb3bH2jj/XclFVAX/xEUkG9efhdRHjbEH5RY6cmdJ7bmf7zqjwIQ==",
             "dev": true,
             "requires": {
                 "vite-plugin-full-reload": "^1.0.1"

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
         "autoprefixer": "^10.4.0",
         "cross-env": "^7.0",
         "css-loader": "^5.2.7",
-        "laravel-vite-plugin": "^0.5.3",
+        "laravel-vite-plugin": "^0.6.1",
         "postcss": "^8.4.5",
         "postcss-import": "^14.0.1",
         "tailwindcss": "^3.0.19",


### PR DESCRIPTION
Changes introduced in https://github.com/statamic/cms/pull/6752 require laravel-vite-plugin >= 0.6